### PR TITLE
set MTU on localnet NAD

### DIFF
--- a/networking/components/vlan-1924/ovs-bridge/nad.yaml
+++ b/networking/components/vlan-1924/ovs-bridge/nad.yaml
@@ -12,11 +12,12 @@ spec:
   # via NNCP in an OVN bridge-mapping
   config: |-
     {
-      "cniVersion": "0.3.1", 
+      "cniVersion": "0.4.0",
       "name": "vlan-1924",
-      "type": "ovn-k8s-cni-overlay", 
-      "topology": "localnet", 
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
       "netAttachDefName": "default/vlan-1924",
       "vlanID": 1924,
+      "mtu": 1500,
       "ipam": {}
     }

--- a/networking/components/vlan-1926/ovs-bridge/nad.yaml
+++ b/networking/components/vlan-1926/ovs-bridge/nad.yaml
@@ -12,11 +12,12 @@ spec:
   # via NNCP in an OVN bridge-mapping
   config: |-
     {
-      "cniVersion": "0.3.1", 
-      "name": "vlan-1926", 
-      "type": "ovn-k8s-cni-overlay", 
-      "topology": "localnet", 
+      "cniVersion": "0.4.0",
+      "name": "vlan-1926",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
       "netAttachDefName": "default/vlan-1926",
       "vlanID": 1926,
+      "mtu": 1500,
       "ipam": {}
     }


### PR DESCRIPTION
by default the MTU will be decreased by 100 as if this were an overlay being encapsulated by geneve, but this is not necessary for localnet which is a provider network

by omitting this failures will occur transferring data and eg. pxebooting

see also https://gist.github.com/dlbewley/5264935f02e3ed1416012c4494249b93